### PR TITLE
Handle conflicting description name updates & label reset

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -279,3 +279,6 @@
 
 - [ ] **Add projected savings**:
    - This likely requires some additional tables to be created to store monthly saving amounts for each bucket
+
+- [ ] **Create audit history logs for shared_transactions**:
+   - Triggers to be performed in the psql tables directly and not in python.


### PR DESCRIPTION
- Edge case was present whereby pending transactions had updated names after the transaction was fully processed. This caused the bank_category and label columsnto be resetted for some reason. shared_bank_feed.py has been updated to ensure these two columns are retained whilst the transaction name change occurs.